### PR TITLE
Deprecate `normalize` method

### DIFF
--- a/docs/draft.md
+++ b/docs/draft.md
@@ -13,7 +13,7 @@ df_member_casual = df.cal.aggregate_events("member_casual", timestamp_col="start
 
 (
     df_member_casual
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row()
 )
 fig = plt.gcf()

--- a/docs/examples/cal-attribute.md
+++ b/docs/examples/cal-attribute.md
@@ -93,7 +93,7 @@ Custom [color maps](./../modules/plot/colors.md#latent_calendar.plot.colors) can
 ```python
 (
     df_member_casual
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row()
 )
 fig = plt.gcf()

--- a/docs/examples/datasets/bikes-in-chicago.md
+++ b/docs/examples/datasets/bikes-in-chicago.md
@@ -52,7 +52,7 @@ df_wide = df.cal.aggregate_events("week_of_year", "started_at")
 
 (
     df_wide
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row()
 )
 fig = plt.gcf()
@@ -83,7 +83,7 @@ plot_storms = create_plot_storms_func(first_storm, second_storm)
 
 (
     df_wide
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row()
 )
 fig = plt.gcf()
@@ -111,7 +111,7 @@ def title_func(idx, row) -> str:
 
 (
     df_wide
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row(max_cols=2, title_func=title_func)
 )
 fig = plt.gcf()
@@ -162,9 +162,6 @@ member        2023-06-26 until 2023-07-02           7949           8960         
 Visualizing this data, we can see the heavy impact of the Sunday weather for casual riders and members alike but not enough to ruin the holiday weekend.
 
 ```python
-
-
-
 def replace_index(ser: pd.Series, index: pd.Index) -> pd.Series:
     ser.index = index
     return ser

--- a/docs/examples/datasets/store-transactions.md
+++ b/docs/examples/datasets/store-transactions.md
@@ -50,7 +50,7 @@ countries = ["United Kingdom", "Germany", "France"]
 (
     df_wide
     .loc[countries]
-    .cal.normalize("max")
+    .cal.divide_by_max()
     .cal.plot_by_row()
 )
 fig = plt.gcf()

--- a/docs/examples/datasets/ufo-sightings.md
+++ b/docs/examples/datasets/ufo-sightings.md
@@ -64,7 +64,7 @@ for aggregation, ax in zip(["dow", "hour"], axes.ravel()[1:]):
     (
         df_5_year
         .cal.sum_over_vocab(aggregation=aggregation)
-        .cal.normalize("probs")
+        .cal.divide_by_sum()
         .mul(100)
         .T.plot(ax=ax)
     )

--- a/latent_calendar/extensions.py
+++ b/latent_calendar/extensions.py
@@ -79,8 +79,6 @@ Examples:
 
 """
 
-from typing import Literal
-
 import narwhals as nw
 
 import pandas as pd
@@ -351,6 +349,8 @@ class PandasDataFrameAccessor:
     def divide_by_max(self) -> pd.DataFrame:
         """Divide each row by the max value.
 
+        Use before plotting to normalize the values to [0, 1].
+
         Returns:
             DataFrame with row-wise operations applied
 
@@ -359,6 +359,8 @@ class PandasDataFrameAccessor:
 
     def divide_by_sum(self) -> pd.DataFrame:
         """Divide each row by the sum of the row.
+
+        Use to create an empirical probability distribution for each row.
 
         Returns:
             DataFrame with row-wise operations applied
@@ -369,48 +371,15 @@ class PandasDataFrameAccessor:
     def divide_by_even_rate(self) -> pd.DataFrame:
         """Divide each row by the number of columns.
 
+        Use to create a relative rate compared to an even distribution. Greater than
+        1 indicates the row has more events than expected under an even distribution.
+
         Returns:
             DataFrame with row-wise operations applied
 
         """
         value = self._obj.shape[1]
         return self._obj.mul(value)
-
-    def normalize(self, kind: Literal["max", "probs", "even_rate"]) -> pd.DataFrame:
-        """Row-wise operations on DataFrame.
-
-        Args:
-            kind: The normalization to apply.
-
-        Returns:
-            DataFrame with row-wise operations applied
-
-        """
-        import warnings
-
-        def warn(message):
-            warnings.warn(message, DeprecationWarning, stacklevel=3)
-
-        warning_message = "This method will be deprecated in future versions"
-
-        funcs = {
-            "max": self.divide_by_max,
-            "probs": self.divide_by_sum,
-            "even_rate": self.divide_by_even_rate,
-        }
-
-        if kind not in funcs:
-            warn(warning_message)
-            raise ValueError(
-                f"kind must be one of ['max', 'probs', 'even_rate'], got {kind}"
-            )
-
-        func = funcs[kind]
-
-        warning_message = f"{warning_message} in favor of df.cal.{func.__name__}()"
-        warn(warning_message)
-
-        return func()
 
     def conditional_probabilities(
         self,

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -72,7 +72,7 @@ def df_segments() -> pd.DataFrame:
     ).T
 
 
-def test_max_normalize(df) -> None:
+def test_divide_by_max(df) -> None:
     df_max_result = pd.DataFrame(
         {
             "a": [1 / 3, 2 / 3, 1],
@@ -80,18 +80,13 @@ def test_max_normalize(df) -> None:
         }
     ).T
 
-    with pytest.warns(DeprecationWarning):
-        pd.testing.assert_frame_equal(
-            df.cal.normalize("max"),
-            df_max_result,
-        )
     pd.testing.assert_frame_equal(
         df.cal.divide_by_max(),
         df_max_result,
     )
 
 
-def test_sum_normalize(df) -> None:
+def test_divide_by_sum(df) -> None:
     df_probs_result = pd.DataFrame(
         {
             "a": [1 / 6, 2 / 6, 3 / 6],
@@ -99,19 +94,13 @@ def test_sum_normalize(df) -> None:
         }
     ).T
 
-    with pytest.warns(DeprecationWarning):
-        pd.testing.assert_frame_equal(
-            df.cal.normalize("probs"),
-            df_probs_result,
-        )
-
     pd.testing.assert_frame_equal(
         df.cal.divide_by_sum(),
         df_probs_result,
     )
 
 
-def test_even_rate_normalize(df) -> None:
+def test_divide_by_even_rate(df) -> None:
     df_even_rate_result = pd.DataFrame(
         {
             "a": [1 * 3, 2 * 3, 3 * 3],
@@ -119,11 +108,6 @@ def test_even_rate_normalize(df) -> None:
         }
     ).T
 
-    with pytest.warns(DeprecationWarning):
-        pd.testing.assert_frame_equal(
-            df.cal.normalize("even_rate"),
-            df_even_rate_result,
-        )
     pd.testing.assert_frame_equal(
         df.cal.divide_by_even_rate(),
         df_even_rate_result,
@@ -144,12 +128,6 @@ def test_even_rate_probability_distribution(df) -> None:
         df_probs.cal.divide_by_even_rate(),
         df_even_rate_result,
     )
-
-
-def test_unknown_normalize(df) -> None:
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError):
-            df.cal.normalize("unknown")
 
 
 def test_all_dataframe_extensions(df, df_segments) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1271,7 +1271,7 @@ wheels = [
 
 [[package]]
 name = "latent-calendar"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "conjugate-models" },


### PR DESCRIPTION
This deprecates the `normalize` method in favor of: 

- probs: `divide_by_sum`
- max: `divide_by_max`
- even_rate: `divide_by_even_rate`
