### PR TITLE
Add deprecation label to the release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
     labels:
       - no releasenotes
   categories:
+    - title: Deprecations ⚠️
+      labels:
+        - deprecation
     - title: New Features 🎉
       labels:
         - enhancement


### PR DESCRIPTION
This makes use of the `deprecations` label in GitHub when in the release template